### PR TITLE
🐛 Fix: 전역 폰트 설정 오류 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "clsx": "^2.1.1",
+    "pretendard": "^1.3.9",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.10.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      pretendard:
+        specifier: ^1.3.9
+        version: 1.3.9
       react:
         specifier: ^19.2.0
         version: 19.2.1
@@ -788,6 +791,9 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  pretendard@1.3.9:
+    resolution: {integrity: sha512-PaQAADyLY5v4kYFwkpSJHbSSYIkiriY/1xXw75TKoZ9UQQqeU+tvP05yTdZAWibiIYoo8ZKtRv8PM7w0IaywSw==}
+
   react-dom@19.2.1:
     resolution: {integrity: sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==}
     peerDependencies:
@@ -1495,6 +1501,8 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  pretendard@1.3.9: {}
 
   react-dom@19.2.1(react@19.2.1):
     dependencies:

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -1,7 +1,8 @@
 @layer base {
   :root {
     --vh: 100%;
-    --font-family: "Pretendard-Regular";
+    --font-family: "Pretendard", -apple-system, BlinkMacSystemFont, "Segoe UI",
+      Roboto, "Apple SD Gothic Neo", "Noto Sans KR", Arial, sans-serif;
   }
 
   html {
@@ -68,6 +69,7 @@
 
   button {
     @apply cursor-pointer p-0;
+    font-family: inherit;
   }
 
   textarea {

--- a/src/styles/fonts.css
+++ b/src/styles/fonts.css
@@ -1,7 +1,1 @@
-@font-face {
-  font-family: "Pretendard-Regular";
-  src: url("https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff")
-    format("woff");
-  font-weight: 400;
-  font-style: normal;
-}
+@import "pretendard/dist/web/static/pretendard.css";


### PR DESCRIPTION
## 🚀 관련 이슈
- close #12 

## 🔑 작업 내용
- CDN 방식의 설정 → 라이브러리 설치 방식으로 변경

## 📷 스크린샷
**- Pretendard 라이브러리 설치**
<img width="466" height="123" alt="스크린샷 2025-12-23 오후 4 11 39" src="https://github.com/user-attachments/assets/d0034a02-bd1f-4eaf-a66c-cd80ef2f7aef" />

**- 폰트가 없을 경우, 기본 폰트 적용**
<img width="693" height="181" alt="스크린샷 2025-12-23 오후 4 11 55" src="https://github.com/user-attachments/assets/93c21740-7bb3-4a0b-b383-69c159104f32" />

## 🌐 공유 사항 to 리뷰어
- 다른 페이지 개발 중 라이브러리 설치로 package.json 충돌이 나면 잡아주시면 감사하겠습니다!

## 🚨 이슈 사항

