### PR TITLE
✨ Feat: useNavigation 커스텀 훅 추가

### DIFF
--- a/src/hooks/useNavigation.ts
+++ b/src/hooks/useNavigation.ts
@@ -1,0 +1,35 @@
+import { useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import type { NavigateOptions } from "react-router-dom";
+
+type NavigateToOptions = NavigateOptions & {
+  newTab?: boolean;
+};
+
+const isHttpUrl = (path: string) => /^https?:\/\//.test(path);
+
+const useNavigation = () => {
+  const navigate = useNavigate();
+
+  const navigateTo = useCallback(
+    (path: string, options?: NavigateToOptions) => {
+      if (isHttpUrl(path)) {
+        const newTab = options?.newTab ?? true;
+
+        if (newTab) {
+          window.open(path, "_blank", "noopener,noreferrer");
+        } else {
+          window.location.href = path;
+        }
+        return;
+      }
+
+      navigate(path, options);
+    },
+    [navigate]
+  );
+
+  return { navigateTo };
+};
+
+export default useNavigation;


### PR DESCRIPTION
## 🚀 관련 이슈
- close #18 

## 🔑 작업 내용
- 페이지 간, 외부 링크 이동을 위한 useNavigation() 훅 추가했습니다.

## 📷 스크린샷
<img width="366" height="394" alt="스크린샷 2025-12-26 오후 12 24 19" src="https://github.com/user-attachments/assets/7a23f3f2-b6a7-42d8-a6bf-f098e51f2353" />


## 🌐 공유 사항 to 리뷰어
- 기존 및 신규 기능의 라우팅 처리 부분은 공통 useNavigation 훅을 사용하도록 수정 부탁드립니다!
- 사용 방법
```
// 훅 가져오기
import useNavigation from "@/hooks/useNavigation";

// 컴포넌트에서 사용
const { navigateTo } = useNavigation();

// 내부 라우팅
navigateTo("/login");
navigateTo("/profile", { replace: true });

// 외부 링크로 이동
// 기본적으로 새 탭으로 열림
navigateTo("https://example.com");
// 같은 탭으로 열고 싶을 경우
navigateTo("https://example.com", { newTab: false });
```

## 🚨 이슈 사항

