### PR TITLE
♻️ Refactor: Qna 페이지 UI 리팩토링

### DIFF
--- a/src/pages/qna/Qna.tsx
+++ b/src/pages/qna/Qna.tsx
@@ -13,8 +13,8 @@ const Qna = () => {
     QnaData.find((item) => item.type === selectedType)?.qna ?? [];
 
   return (
-    <div className="pageContainer">
-      <Title text="FAQ" />
+    <div className="pageContainer flex flex-col gap-y-[clamp(1.62rem,4vw,3.73rem)] pb-[clamp(25.8rem,6vw,27.9rem)]">
+      <Title text="QnA" />
 
       <ListFilter
         types={QNA_TYPES}

--- a/src/pages/qna/components/Filter/ItemFilter.tsx
+++ b/src/pages/qna/components/Filter/ItemFilter.tsx
@@ -13,7 +13,7 @@ const ItemFilter = ({ type, isSelected, onClick }: ItemFilterProps) => {
       onClick={onClick}
       aria-pressed={isSelected}
       className={clsx(
-        `rounded-[clamp(25rem,60vw,50rem)] border-[clamp(0.05rem,0.3vw,0.1rem)] border-banner-bg-4 px-[clamp(1rem,3vw,2rem)] py-[clamp(0.4rem,1.5vw,0.8rem)] font-medium text-[clamp(1.4rem,3vw,2.8rem)] text-banner-bg-4`,
+        `rounded-[clamp(25rem,60vw,50rem)] border-[clamp(0.05rem,0.3vw,0.1rem)] border-banner-bg-4 px-[clamp(1rem,2vw,2rem)] py-[clamp(0.4rem,0.5vw,0.8rem)] font-medium text-[clamp(1.4rem,2vw,2.8rem)] text-banner-bg-4`,
         isSelected && "bg-banner-bg-4 font-semibold text-footer"
       )}
     >

--- a/src/pages/qna/components/Filter/ListFilter.tsx
+++ b/src/pages/qna/components/Filter/ListFilter.tsx
@@ -9,7 +9,7 @@ interface ListFilterProps {
 
 const ListFilter = ({ types, selectedType, onSelectType }: ListFilterProps) => {
   return (
-    <div className="mt-[clamp(2.6rem,5vw,7rem)] mb-[clamp(2.3rem,5vw,8rem)] flex items-center gap-[clamp(0.8rem,2vw,2rem)]">
+    <div className="flex items-center gap-[clamp(0.8rem,1.5vw,2rem)]">
       {types.map((type) => (
         <ItemFilter
           key={type}

--- a/src/pages/qna/components/Qna/ItemQna.tsx
+++ b/src/pages/qna/components/Qna/ItemQna.tsx
@@ -11,20 +11,20 @@ const ItemQna = ({ question, answer }: ItemQnaProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <div className="w-full rounded-[clamp(0.28rem,1.5vw,1rem)] bg-qna-4 p-[clamp(1.1rem,5vw,4rem)]">
+    <div className="w-full rounded-[clamp(0.28rem,1.5vw,1rem)] bg-qna-4 p-[clamp(1.15rem,3vw,4rem)]">
       <button
         onClick={() => setIsOpen((prev) => !prev)}
         className="relative w-full text-left"
         aria-expanded={isOpen}
       >
-        <div className="flex max-w-[90%] items-start gap-[clamp(0.316rem,1.5vw,1.1rem)] text-[clamp(1.3rem,2.5vw,3rem)] text-intro">
+        <div className="flex max-w-[90%] items-start gap-[clamp(0.316rem,0.7vw,1.1rem)] text-[clamp(1.3rem,2vw,3rem)] text-intro">
           <span className="shrink-0 font-semibold">Q.</span>
 
           <div className="flex w-fit flex-col">
             <span className="font-medium">{question}</span>
 
             {isOpen && (
-              <p className="mt-[clamp(1.15rem,4vw,4rem)] text-[clamp(1.1rem,3vw,2.6rem)] text-modal-2 leading-[1.4]">
+              <p className="mt-[clamp(1.15rem,3vw,4rem)] text-[clamp(1.1rem,2vw,2.6rem)] text-modal-2 leading-[1.4]">
                 {answer}
               </p>
             )}
@@ -33,7 +33,7 @@ const ItemQna = ({ question, answer }: ItemQnaProps) => {
 
         <img
           className={clsx(
-            "absolute top-0 right-0 w-[clamp(1.6rem,4vw,3.6rem)] transition-transform duration-300",
+            "absolute top-0 right-0 w-[clamp(1.6rem,2.5vw,3.6rem)] transition-transform duration-300",
             isOpen && "rotate-180"
           )}
           src={ArrowDown}

--- a/src/pages/qna/components/Qna/ListQna.tsx
+++ b/src/pages/qna/components/Qna/ListQna.tsx
@@ -7,7 +7,7 @@ interface ListQnaProps {
 
 const ListQna = ({ qnaList }: ListQnaProps) => {
   return (
-    <div className="mb-[clamp(25.8rem,6vw,27.9rem)] flex w-full flex-col gap-[clamp(2rem,4vw,3.7rem)]">
+    <div className="flex w-full flex-col gap-[clamp(2rem,4vw,3.7rem)]">
       {qnaList.map((qna) => (
         <ItemQna key={qna.id} question={qna.question} answer={qna.answer} />
       ))}


### PR DESCRIPTION
## 🚀 관련 이슈
- close #27 

## 🔑 작업 내용
- Qna 페이지 UI 리팩토링(반응형 위주)

## 📷 스크린샷
<img width="1512" height="982" alt="스크린샷 2026-01-02 오후 4 48 42" src="https://github.com/user-attachments/assets/8a12cf8e-8d2d-415e-851e-4e5e4aef3e81" />
<img width="1512" height="982" alt="스크린샷 2026-01-02 오후 4 48 51" src="https://github.com/user-attachments/assets/53e10379-1058-454d-974e-8f61031c378b" />


## 🌐 공유 사항 to 리뷰어
- project 페이지와 필터 버튼 스타일 맞췄습니다.
- title, 필터, list-qna 부분의 간격도 project 페이지와 맞췄습니다.

## 🚨 이슈 사항

