### PR TITLE
🎨 Design: NotFound 페이지 UI 구현

### DIFF
--- a/src/pages/notFound/NotFound.tsx
+++ b/src/pages/notFound/NotFound.tsx
@@ -1,5 +1,34 @@
+import useNavigation from "@/hooks/useNavigation";
+
 const NotFound = () => {
-  return <>NotFound</>;
+  const { navigateTo } = useNavigation();
+
+  const handleHomeClick = () => {
+    navigateTo("/");
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center text-white text-center">
+      <h1 className="text-6xl font-bold tracking-wider text-white/90">404</h1>
+
+      <h2 className="mt-4 text-xl font-semibold text-white/70">
+        페이지를 찾을 수 없습니다
+      </h2>
+
+      <p className="mt-3 text-sm text-white/60 max-w-md">
+        요청하신 페이지가 존재하지 않거나 이동되었을 수 있습니다.
+        <br />
+        아래 버튼을 눌러 홈으로 돌아가세요.
+      </p>
+
+      <button
+        onClick={handleHomeClick}
+        className="mt-8 px-6 py-3 rounded-lg bg-white text-black font-semibold transition hover:bg-banner-bg-4 text-lg"
+      >
+        홈으로 이동
+      </button>
+    </div>
+  );
 };
 
 export default NotFound;


### PR DESCRIPTION
## 🚀 관련 이슈
- close #56 

## 🔑 작업 내용
- NotFound 페이지 UI 구현했습니다.
- 홈으로 이동 버튼 클릭 시 메인 페이지로 라우팅되도록 처리했습니다.

## 📷 스크린샷
<img width="1512" height="982" alt="스크린샷 2026-02-24 오후 8 57 39" src="https://github.com/user-attachments/assets/5d325c02-674d-4abd-83fd-6310f07dd2ad" />

## 🌐 공유 사항 to 리뷰어

## 🚨 이슈 사항
